### PR TITLE
Fix hostname of Linkedin

### DIFF
--- a/highlighter.js
+++ b/highlighter.js
@@ -10,7 +10,7 @@ const options = ({
   },
   isWindowLocationValid: function (windowLocation) {
     const blacklistedHosts = [
-      'linkedin.com',
+      'www.linkedin.com',
       'collabedit.com',
       'coderpad.io',
       'jsbin.com',

--- a/optionsPage.js
+++ b/optionsPage.js
@@ -16,7 +16,7 @@ const defaultOptions = `({
 
   isWindowLocationValid: function (windowLocation) {
     const blacklistedHosts = [
-      'linkedin.com',
+      'www.linkedin.com',
       'collabedit.com',
       'coderpad.io',
       'jsbin.com',


### PR DESCRIPTION
`window.location.host` of Linkedin is actually `www.linkedin.com` according to my test, and the original `isWindowLocationValid` will return true for Linkedin.