### PR TITLE
Replace mark by span because it was causing issues on some websites

### DIFF
--- a/src/highlighter/highlighter.js
+++ b/src/highlighter/highlighter.js
@@ -104,7 +104,7 @@ chrome.storage.sync.get('optionsText', e => {
 });
 
 function initialize () {
-  const highlightedMarkTemplate = document.createElement('mark');
+  const highlightedMarkTemplate = document.createElement('span');
     highlightedMarkTemplate.className = options.highlightedClassName;
   Object.entries(options.styles).forEach(([styleName, styleValue]) => {
     highlightedMarkTemplate.style[styleName] = styleValue;


### PR DESCRIPTION
Is there a reason for requiring it to be mark? Mark was causing this issue on this page, and it was fixed after I replaced it by span.

Site: https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setunhandledexceptionfilter?redirectedfrom=MSDN

mark
![image](https://user-images.githubusercontent.com/5332158/117558510-71ec8700-b054-11eb-8814-6071d7259add.png)

span
![image](https://user-images.githubusercontent.com/5332158/117558530-b9731300-b054-11eb-8fad-483da4d7f443.png)
