### PR TITLE
Add black default text color

### DIFF
--- a/src/chrome_extension/options/types.ts
+++ b/src/chrome_extension/options/types.ts
@@ -6,7 +6,7 @@ export const defaultOptions: Options = {
   matchCaseSensitive: false,
   highlightStylesObject: {
     "background-color": "rgba(255,255,0,1)", // yellow 100%
-    color: 'rgba(0,0,0,1)', // black 100%
+    color: "rgba(0,0,0,1)", // black 100%
   },
   enableScrollMarkers: true,
   scrollMarkersDebounce: 0,

--- a/src/chrome_extension/options/types.ts
+++ b/src/chrome_extension/options/types.ts
@@ -6,6 +6,7 @@ export const defaultOptions: Options = {
   matchCaseSensitive: false,
   highlightStylesObject: {
     "background-color": "rgba(255,255,0,1)", // yellow 100%
+    color: 'rgba(0,0,0,1)', // black 100%
   },
   enableScrollMarkers: true,
   scrollMarkersDebounce: 0,

--- a/src/firefox_extension/options/default_options_text.js
+++ b/src/firefox_extension/options/default_options_text.js
@@ -62,6 +62,7 @@ export const defaultOptionsText = `({
 
   styles: {
     backgroundColor: 'rgb(255,255,0,1)', // yellow 100%
+    color: 'rgba(0,0,0,1)', // black 100%
     margin: '0',
     padding: '0',
     // lineHeight: '1',


### PR DESCRIPTION
Hey @neaumusic, hope things are going well!

Just a quick PR to add contrast to the highlighted text

Before:

![Screenshot 2023-08-09 at 18 14 44](https://github.com/neaumusic/selection-highlighter/assets/1935696/f7b5defb-0358-4a7d-b73d-6ea3532644ad)

After:

![Screenshot 2023-08-09 at 18 14 23](https://github.com/neaumusic/selection-highlighter/assets/1935696/e51770da-f573-4412-b210-712462272007)

This is also more similar to the built-in find match highlighting by Chrome:

![Screenshot 2023-08-09 at 18 16 54](https://github.com/neaumusic/selection-highlighter/assets/1935696/81782e16-9015-4d75-a3c9-8a58f4eaa4c2)
